### PR TITLE
Load old messages

### DIFF
--- a/app/assets/javascripts/channels/messages.js.erb
+++ b/app/assets/javascripts/channels/messages.js.erb
@@ -1,10 +1,22 @@
-var messageFormContent = document.querySelector('#message_content');
+var messageFormContent = document.getElementById('message_content');
 var messages = document.getElementById('messages');
+var messagesPanel = document.getElementById('messages-panel');
+
+var observer = new MutationObserver(scrollToBottom);
+var messages = document.getElementById('messages');
+const config = { childList: true };
+
+function scrollToBottom() {
+  messagesPanel.scrollTop = messagesPanel.scrollHeight;
+}
 
 <% Group.all.each do |group| %>
 
   App['group' + <%= group.id %>] = App.cable.subscriptions.create({channel: 'MessagesChannel', group_id: <%= group.id %> }, {
     received: function(data) {
+      // Scroll to last message on new message
+      observer.observe(messages, config);
+
       // data.message is pre-rendered html from the partial _message.html.erb
       return messages.insertAdjacentHTML('beforeend', data.message);
     },

--- a/app/assets/javascripts/channels/messages.js.erb
+++ b/app/assets/javascripts/channels/messages.js.erb
@@ -1,14 +1,12 @@
 var messageFormContent = document.querySelector('#message_content');
-var messages = document.querySelector("#messages");
+var messages = document.getElementById('messages');
 
 <% Group.all.each do |group| %>
 
   App['group' + <%= group.id %>] = App.cable.subscriptions.create({channel: 'MessagesChannel', group_id: <%= group.id %> }, {
     received: function(data) {
-      html = data.date + data.message
-      // console.log(data.date + date.message)
       // data.message is pre-rendered html from the partial _message.html.erb
-      return messages.insertAdjacentHTML('beforeend', html);
+      return messages.insertAdjacentHTML('beforeend', data.message);
     },
   });
 <% end %>
@@ -27,7 +25,7 @@ function submitMessage(){
   var content = messageFormContent.value
   if (content == '') { return false }
 
-  var groupId = document.querySelector('[data-group]').dataset.group
+  var groupId = messages.dataset.group
 
   App['group' + groupId].send({content: content, group_id: groupId})
 

--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -1,8 +1,13 @@
-#messages {
+#messages-panel {
   display: flex;
   flex-direction: column;
   height: 250px;
   overflow-y: auto;
+}
+
+#messages {
+  display: flex;
+  flex-direction: column;
 }
 
 .message {
@@ -37,4 +42,13 @@
   left: 520px;
   border-radius: 50%;
   height: 70px;
+}
+
+#message-load-icon {
+  align-self: center;
+  background-color: white;
+  text-align: center;
+  border-radius: 50%;
+  width: 25px;
+  margin: 25px 0 ;
 }

--- a/app/assets/stylesheets/components/_messages.scss
+++ b/app/assets/stylesheets/components/_messages.scss
@@ -15,6 +15,7 @@
   border-radius: 5px;
   margin: 5px 0;
   padding: 5px;
+  width: 70%;
 }
 
 .message-content {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -13,8 +13,7 @@ class GroupsController < ApplicationController
     @members.sort!{ |x, y| x.first_name <=> y.first_name }
     @group_statistics = group_statistics
     @message = Message.new
-    unformatted_messages = @group.messages.reverse_order.page().per(10).reverse
-    @messages = format_messages(unformatted_messages)
+    @messages = @group.messages.reverse_order.page.reverse
   end
 
   def new
@@ -66,22 +65,5 @@ class GroupsController < ApplicationController
 
   def group_statistics
     {'Total drinks made' => 0, 'Avg. person per round' => 0, 'Hours since last brew' => 0}
-  end
-
-  def format_messages(messages)
-    hash = {}
-
-    messages.each do |message|
-      if Date.today == message.created_at.to_date
-        date = "Today"
-      else
-        date = message.created_at.strftime('%D')
-      end
-
-      hash[date] = [] if hash[date].nil?
-
-      hash[date] << message
-    end
-    return hash
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,7 @@ class MessagesController < ApplicationController
     @messages_html = @messages.map do |message|
       ApplicationController.renderer.render(
         partial: 'messages/message',
-        locals: { message: message }
+        locals: { message: message, current_user: current_user }
       )
     end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,22 +1,37 @@
 class MessagesController < ApplicationController
-  before_action :find_group, only: [ :create ]
+  before_action :find_group, only: [ :index, :create ]
 
-  def create
-    @message = Message.new(message_params)
-    @message.group = @group
-    @message.user = current_user
-    authorize @message
-    if @message.save
-      # ActionCable.server.broadcast "group-#{@group.id}:messages",
-      #   message: @message
-      # head :ok
-    else
-      respond_to do |format|
-        format.html { redirect_to groups_path(@group) }
-        format.js
-      end
+  def index
+    @messages = policy_scope(Message).reverse_order.page(params[:page])
+
+    @messages_html = @messages.map do |message|
+      ApplicationController.renderer.render(
+        partial: 'messages/message',
+        locals: { message: message }
+      )
+    end
+
+    respond_to do |format|
+      format.js
+      format.html { redirect_to group_path(@group) }
     end
   end
+
+  # def create
+    # @message = Message.new(message_params)
+    # @message.group = @group
+    # @message.user = current_user
+    # authorize @message
+
+    # if @message.save!
+
+    # else
+    #   respond_to do |format|
+    #     format.html { redirect_to group_path(@group) }
+    #     format.js
+    #   end
+    # end
+  # end
 
   private
 
@@ -26,5 +41,9 @@ class MessagesController < ApplicationController
 
   def find_group
     @group = Group.find(params[:group_id])
+  end
+
+  def pundit_user
+    @group
   end
 end

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -14,7 +14,7 @@ class MessageBroadcastJob < ApplicationJob
   def render_message(message)
     ApplicationController.renderer.render(
       partial: 'messages/message',
-      locals: { message: message }
+      locals: { message: message, current_user: message.user }
       )
   end
 

--- a/app/jobs/message_broadcast_job.rb
+++ b/app/jobs/message_broadcast_job.rb
@@ -4,8 +4,8 @@ class MessageBroadcastJob < ApplicationJob
   def perform(payload)
     ActionCable.server.broadcast(
       "group-#{payload[:message].group.id}:messages",
-      message: render_message(payload[:message]),
-      date: render_date(payload[:new_date])
+      message: render_message(payload[:message])
+      # date: render_date(payload[:new_date])
       )
   end
 
@@ -18,14 +18,14 @@ class MessageBroadcastJob < ApplicationJob
       )
   end
 
-  def render_date(new_date)
-    if new_date
-      return ApplicationController.renderer.render(
-              partial: 'messages/message_date',
-              locals: { date: "Today" }
-              )
-    else
-      return ''
-    end
-  end
+  # def render_date(new_date)
+  #   if new_date
+  #     return ApplicationController.renderer.render(
+  #             partial: 'messages/message_date',
+  #             locals: { date: "Today" }
+  #             )
+  #   else
+  #     return ''
+  #   end
+  # end
 end

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -1,7 +1,8 @@
 class MessagePolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      scope
+      # user == a group instance
+      scope.where(group_id: user.id)
     end
   end
 

--- a/app/views/group_members/create.html.erb
+++ b/app/views/group_members/create.html.erb
@@ -1,2 +1,0 @@
-<h1>UserGroups#create</h1>
-<p>Find me in app/views/user_groups/create.html.erb</p>

--- a/app/views/group_members/destroy.html.erb
+++ b/app/views/group_members/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>UserGroups#destroy</h1>
-<p>Find me in app/views/user_groups/destroy.html.erb</p>

--- a/app/views/group_members/new.html.erb
+++ b/app/views/group_members/new.html.erb
@@ -1,2 +1,0 @@
-<h1>UserGroups#new</h1>
-<p>Find me in app/views/user_groups/new.html.erb</p>

--- a/app/views/groups/_group_admin_options.html.erb
+++ b/app/views/groups/_group_admin_options.html.erb
@@ -1,5 +1,5 @@
 <div class="dropdown group-dropdown">
-  <i class="fa fa-bars dropdown-toggle" data-toggle="dropdown"></i>
+  <i class="fas fa-cog dropdown-toggle" data-toggle="dropdown"></i>
   <ul class="dropdown-menu dropdown-menu-right navbar-wagon-dropdown-menu">
     <% if current_user.group_admin?(@group) %>
       <li>

--- a/app/views/groups/_group_members.html.erb
+++ b/app/views/groups/_group_members.html.erb
@@ -1,0 +1,16 @@
+<div class="group-members">
+  <h4>Group Members</h4>
+  <% members.each do |member| %>
+    <div class="group-member">
+      <% if current_user.group_admin?(group) %>
+        <%= link_to group_group_member_path(group, member), method: :delete, data: { confirm: 'Are you sure?' }, class: "remove-members hidden" do %>
+          <i class="fa fa-times"></i>
+        <% end %>
+      <% end %>
+      <p><%= member.full_name %> </p>
+      <% if member.group_admin?(group) %>
+        <p class="admin-badge"><%= "Admin" %></p>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -62,11 +62,11 @@
     scrollToBottom();
 
     // Scroll messages to bottom on new message
-    var observer = new MutationObserver(scrollToBottom);
-    var messages = document.getElementById('messages');
-    const config = { childList: true };
+    // var observer = new MutationObserver(scrollToBottom);
+    // var messages = document.getElementById('messages');
+    // const config = { childList: true };
 
-    observer.observe(messages, config);
+    // observer.observe(messages, config);
 
     function scrollToBottom() {
       messagesPanel.scrollTop = messagesPanel.scrollHeight;
@@ -88,7 +88,6 @@
 
     var loadIconInView = (messageTitle, loadIcon) => {
       var diff = loadIcon.getBoundingClientRect().y - messageTitle.getBoundingClientRect().y
-      console.log(diff)
       if (diff > 62 ) {
         return true
       } else {

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -18,32 +18,20 @@
       </div>
     </div>
     <div class="col-xs-12 col-md-6">
-      <div class="group-members">
-        <h4>Group Members</h4>
-        <% @members.each do |member| %>
-          <div class="group-member">
-            <% if current_user.group_admin?(@group) %>
-              <%= link_to group_group_member_path(@group, member), method: :delete, data: { confirm: 'Are you sure?' }, class: "remove-members hidden" do %>
-                <i class="fa fa-times"></i>
-              <% end %>
-            <% end %>
-            <p><%= member.full_name %> </p>
-            <% if member.group_admin?(@group) %>
-              <p class="admin-badge"><%= "Admin" %></p>
-            <% end %>
-          </div>
-        <% end %>
-      </div>
+      <%= render 'groups/group_members', group: @group, members: @members %>
     </div>
     <div class="col-xs-12 col-md-6">
-      <h4>Messages</h4>
-        <div id="messages" data-group=<%= @group.id %>>
-          <% @messages.each do |date, messages| %>
-            <%= render 'messages/message_date', date: date %>
-            <% messages.each do |message| %>
+      <h4 id="messages-panel-header">Messages</h4>
+        <div id="messages-panel">
+          <form action="/groups/<%= @group.id %>/messages" method="get" data-remote="true" id="load-old-messages-form">
+            <input id="pagination_counter" type="text" name="page" value="2" class="hidden">
+          </form>
+          <div id="message-load-icon"><i class="fas fa-spin fa-sync-alt"></i></div>
+          <div id="messages" data-group=<%= @group.id %>>
+            <% @messages.each do |message| %>
               <%= render 'messages/message', message: message %>
             <% end %>
-          <% end %>
+          </div>
         </div>
       <br>
       <%= render 'messages/message_form', group: @group, message: @message %>
@@ -65,19 +53,50 @@
     const btn = document.querySelector("#removeAMemberBtn");
 
     btn.addEventListener("click", revealBtns);
+  });
+
+  document.addEventListener("DOMContentLoaded", () => {
 
     // Scroll messages panel to the bottom on page load
-    var messages = document.getElementById('messages');
+    var messagesPanel = document.getElementById('messages-panel');
     scrollToBottom();
 
     // Scroll messages to bottom on new message
     var observer = new MutationObserver(scrollToBottom);
+    var messages = document.getElementById('messages');
     const config = { childList: true };
+
     observer.observe(messages, config);
 
     function scrollToBottom() {
-      messages.scrollTop = messages.scrollHeight;
+      messagesPanel.scrollTop = messagesPanel.scrollHeight;
     }
+  });
+
+  document.addEventListener("DOMContentLoaded", () => {
+    var messagesPanel = document.getElementById('messages-panel');
+    var messageTitle = document.getElementById('messages-panel-header');
+    var loadIcon = document.getElementById('message-load-icon');
+
+    messagesPanel.addEventListener('scroll', () => {
+      if (loadIconInView(messageTitle, loadIcon)) {
+        // Load old messages
+        var form = document.getElementById('load-old-messages-form');
+        Rails.fire(form, 'submit');
+      }
+    })
+
+    var loadIconInView = (messageTitle, loadIcon) => {
+      var diff = loadIcon.getBoundingClientRect().y - messageTitle.getBoundingClientRect().y
+      console.log(diff)
+      if (diff > 62 ) {
+        return true
+      } else {
+        return false
+      }
+    }
+
+    // messagesPanel.addEventListener('scroll', getOldMessages());
   });
 </script>
 

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,4 +1,4 @@
-<div class="message">
+<div class="message" style="<%= 'text-align: right; align-self: flex-end' if message.user == current_user %>">
   <div class="message-user">
     <p><%= link_to message.user.first_name, user_profile_path(message.user) %> - <%= message.created_at.strftime('%e %b - %H:%M') %></p>
   </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,6 @@
 <div class="message">
   <div class="message-user">
-    <p><%= link_to message.user.first_name, user_profile_path(message.user) %> <%= message.created_at.strftime('%H:%M') %></p>
+    <p><%= link_to message.user.first_name, user_profile_path(message.user) %> - <%= message.created_at.strftime('%e %b - %H:%M') %></p>
   </div>
   <div class="message-content">
     <%= message.content %>

--- a/app/views/messages/_message_form.html.erb
+++ b/app/views/messages/_message_form.html.erb
@@ -1,4 +1,4 @@
-<input class="form-control" data-input="message" name="message[content]" id="message_content">
+<input class="form-control" data-input="message" name="message[content]" id="message_content" placeholder="Type your message...">
 </input>
 
 <!-- <input type="submit" name="commit" value="send" class="btn btn-primary" style="" data-send="message" id="message_form_submit" data-disable-with="send"/>

--- a/app/views/messages/index.js.erb
+++ b/app/views/messages/index.js.erb
@@ -1,0 +1,21 @@
+var messagesPanel = document.getElementById('messages');
+
+<% if @messages_html.empty? %>
+  var loadIcon = document.getElementById('message-load-icon');
+  loadIcon.style.display = 'none';
+<% else %>
+
+  var lastMessage = document.querySelectorAll('.message')[0];
+
+  var paginationCounter = document.getElementById('pagination_counter');
+  paginationCounter.value = parseInt(paginationCounter.value) + 1;
+
+  <% @messages_html.each do |message_html| %>
+    messagesPanel.insertAdjacentHTML('afterBegin', `<%= message_html %>`);
+    lastMessage.scrollIntoView({behaviour: 'smooth', block: 'center'});
+  <% end %>
+
+
+<% end %>
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   resources :groups do
     resources :group_members, only: [:new, :create, :destroy]
 
-    # resources :messages, only: [ :create ]
+    resources :messages, only: [ :index ]
   end
 
   resources :friendships, only: [ :index, :update ]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,10 @@
+puts 'Cleansing DB...'
 Group.destroy_all
 User.destroy_all
 Friendship.destroy_all
 GroupMember.destroy_all
 Message.destroy_all
-
+puts 'DB destroyed! Mwhahahaha'
 users = []
 
 admin = User.create!(email: 'l.b@gmail.com', first_name: 'Luke', last_name: 'Breen', password: '123456')
@@ -20,11 +21,14 @@ User.create!(email: 'v.botella@gmail.com', first_name: 'Victoria', last_name: 'B
 User.create!(email: 'm.heller@gmail.com', first_name: 'Matt', last_name: 'Heller', password: '123456')
 User.create!(email: 's.lacey@gmail.com', first_name: 'Sam', last_name: 'Lacey', password: '123456')
 
+puts 'Created users'
 
 Friendship.create!(user: admin, friend: users[0], status: "accepted")
 Friendship.create!(user: admin, friend: users[1], status: "accepted")
 Friendship.create!(user: admin, friend: users[2], status: "pending")
 Friendship.create!(user: admin, friend: users[3], status: "pending")
+
+puts 'Created friendships between users'
 
 colours = ['rgb(255, 45, 45)', 'rgb(97, 216, 249)', 'rgb(72, 48, 255)', 'rgb(0, 165, 35)', 'rgb(216, 76, 255)', 'rgb(255, 255, 255)']
 
@@ -49,6 +53,8 @@ colours.each_with_index do |colour, index|
   group.save!
 end
 
+puts 'Created groups'
+
 groups = Group.all
 
 Friendship.create!(user: users[0], friend: users[3], status: "accepted")
@@ -61,8 +67,8 @@ Message.create(user: admin, group: group, content: "Who's turn is it?")
 Message.create(user: users[0], group: group, content: "Pretty sure its Will's turn...")
 Message.create(user: users[1], group: group, content: "No wuz but joe's last brew was poor")
 Message.create(user: users[2], group: group, content: "Pfft, you let it go cold")
-
-puts "DB seeded successfully"
+puts 'Created messages'
+puts 'DB seeded successfully'
 
 
 


### PR DESCRIPTION
Issue: "All messages in a chat appear on the page 1) Creates long list of messages 2) Large server demand as every message is fetched"

Solution 1: Messages are contained in a scrolling window, which fetches older messages when scrolled to the top

Solution 2: Only a selection of the last messages are displayed initially in the scroll window

Other changes:

- Current user's messages are aligned to the right